### PR TITLE
feat/0510-69-rolePage-list-empty handle list empty

### DIFF
--- a/src/pages/PrivilegedUsers/index.tsx
+++ b/src/pages/PrivilegedUsers/index.tsx
@@ -205,21 +205,33 @@ export default function PrivilegedUsers() {
 					</thead>
 					<tbody>
 						{userContentPage &&
-							users.map((user) => (
-								<tr key={user.id}>
-									<TableData>{user.username}</TableData>
-									<TableData>{user.email}</TableData>
-									<PrivilegeLabelElement role={user.role} />
-									<SelectUserRole user={user} />
+							(users.length !== 0 ? (
+								users.map((user) => (
+									<tr key={user.id}>
+										<TableData>{user.username}</TableData>
+										<TableData>{user.email}</TableData>
+										<PrivilegeLabelElement role={user.role} />
+										<SelectUserRole user={user} />
+									</tr>
+								))
+							) : (
+								<tr>
+									<TableData colSpan={4}>Nenhuma usuário encontrado</TableData>
 								</tr>
 							))}
 						{solicitaionContentPage &&
-							solicitationUsers.map((solicitation) => (
-								<tr key={solicitation.id}>
-									<TableData>{solicitation.user.username}</TableData>
-									<TableData>{solicitation.user.email}</TableData>
-									<PrivilegeLabelElement role={solicitation.roleReq} />
-									<ActionsUserRole solicitation={solicitation} />
+							(solicitationUsers.length !== 0 ? (
+								solicitationUsers.map((solicitation) => (
+									<tr key={solicitation.id}>
+										<TableData>{solicitation.user.username}</TableData>
+										<TableData>{solicitation.user.email}</TableData>
+										<PrivilegeLabelElement role={solicitation.roleReq} />
+										<ActionsUserRole solicitation={solicitation} />
+									</tr>
+								))
+							) : (
+								<tr>
+									<TableData colSpan={4}>Nenhuma solicitação encontrada</TableData>
 								</tr>
 							))}
 					</tbody>

--- a/src/pages/PrivilegedUsers/index.tsx
+++ b/src/pages/PrivilegedUsers/index.tsx
@@ -216,7 +216,7 @@ export default function PrivilegedUsers() {
 								))
 							) : (
 								<tr>
-									<TableData colSpan={4}>Nenhuma usuário encontrado</TableData>
+									<TableData colSpan={4}>Nenhum usuário encontrado</TableData>
 								</tr>
 							))}
 						{solicitaionContentPage &&


### PR DESCRIPTION
#69 

- Adicionando mensagem na view quando a lista de solicitações e usuários privilegiados forem vazias


### Implementação

```React.js

 <tbody>
	{userContentPage &&
		(users.length !== 0 ? (
			users.map((user) => (
				<tr key={user.id}>
					<TableData>{user.username}</TableData>
					<TableData>{user.email}</TableData>
					<PrivilegeLabelElement role={user.role} />
					<SelectUserRole user={user} />
				</tr>
			))
		) : (
			<tr>
				<TableData colSpan={4}>Nenhuma usuário encontrado</TableData>
			</tr>
		))}
	{solicitaionContentPage &&
		(solicitationUsers.length !== 0 ? (
			solicitationUsers.map((solicitation) => (
				<tr key={solicitation.id}>
					<TableData>{solicitation.user.username}</TableData>
						<TableData>{solicitation.user.email}</TableData>
						<PrivilegeLabelElement role={solicitation.roleReq} />
						<ActionsUserRole solicitation={solicitation} />
				</tr>
			))
		) : (
			<tr>
				<TableData colSpan={4}>Nenhuma solicitação encontrada</TableData>
			</tr>
		))}
</tbody>
```